### PR TITLE
UPSTREAM: <drop>:Updates go-jose replace directive with older version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ replace github.com/prometheus/client_golang => github.com/prometheus/client_gola
 replace github.com/go-asn1-ber/asn1-ber => github.com/go-asn1-ber/asn1-ber v1.5.6
 
 // fix for CVE-2025-27144
-replace github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.0.5
+replace github.com/go-jose/go-jose/v4 v4.0.2 => github.com/go-jose/go-jose/v4 v4.0.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0


### PR DESCRIPTION
The PR is for updating the replace directive used for bumping the indirect `github.com/go-jose/go-jose/v4` package to use the older version, which seems to be causing the konflux build failures, where cachi2 is not including the required version.
```
Go compliance shim [8766] [rhel-9-golang-1.22][openshift-golang-builder]: invoking real go binary
go: downloading github.com/go-jose/go-jose/v4 v4.0.2
/cachi2/output/deps/gomod/pkg/mod/github.com/hashicorp/vault/api@v1.13.0/plugin_helpers.go:16:2: github.com/go-jose/go-jose/v4@v4.0.2: reading file:///cachi2/output/deps/gomod/pkg/mod/cache/download/github.com/go-jose/go-jose/v4/@v/v4.0.2.zip: no such file or directory
/cachi2/output/deps/gomod/pkg/mod/github.com/hashicorp/vault/api@v1.13.0/plugin_helpers.go:17:2: github.com/go-jose/go-jose/v4@v4.0.2: reading file:///cachi2/output/deps/gomod/pkg/mod/cache/download/github.com/go-jose/go-jose/v4/@v/v4.0.2.zip: no such file or directory
```