### PR TITLE
CM-977: UPSTREAM: <carry>: Backport upstream feat to configure certificate request backoff period

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -353,8 +353,9 @@ func buildControllerContextFactory(ctx context.Context, opts *config.ControllerC
 		},
 
 		CertificateOptions: controller.CertificateOptions{
-			EnableOwnerRef:           opts.EnableCertificateOwnerRef,
-			CopiedAnnotationPrefixes: opts.CopiedAnnotationPrefixes,
+			EnableOwnerRef:                           opts.EnableCertificateOwnerRef,
+			CopiedAnnotationPrefixes:                 opts.CopiedAnnotationPrefixes,
+			CertificateRequestMinimumBackoffDuration: opts.CertificateRequestMinimumBackoffDuration,
 		},
 
 		ConfigOptions: controller.ConfigOptions{

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -228,6 +228,10 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.ControllerConfiguration) {
 		"Leader election healthz checks within this timeout period after the lease expires will still return healthy")
 	utilruntime.Must(fs.MarkHidden("internal-healthz-leader-election-timeout"))
 
+	fs.DurationVar(&c.CertificateRequestMinimumBackoffDuration, "certificate-request-minimum-backoff-duration", c.CertificateRequestMinimumBackoffDuration, ""+
+		"Duration of the initial certificate request backoff when a certificate request fails. "+
+		"The backoff duration is exponentially increased based on consecutive failures, up to a maximum of 32 hours.")
+
 	logf.AddFlags(&c.Logging, fs)
 }
 

--- a/internal/apis/config/controller/types.go
+++ b/internal/apis/config/controller/types.go
@@ -133,6 +133,12 @@ type ControllerConfiguration struct {
 
 	// ACMEDNS01Config configures the behaviour of the ACME DNS01 challenge solver
 	ACMEDNS01Config ACMEDNS01Config
+
+	// CertificateRequestMinimumBackoffDuration configures the initial backoff duration
+	// when a certificate request fails. This duration is exponentially increased (up to
+	// a maximum of 32 hours) based on the number of consecutive failures and represents
+	// the minimum backoff applied.
+	CertificateRequestMinimumBackoffDuration time.Duration
 }
 
 type LeaderElectionConfig struct {

--- a/internal/apis/config/controller/v1alpha1/defaults.go
+++ b/internal/apis/config/controller/v1alpha1/defaults.go
@@ -98,6 +98,8 @@ var (
 	defaultACMEHTTP01SolverRunAsNonRoot          = true
 	defaultACMEHTTP01SolverNameservers           = []string{}
 
+	defaultCertificateRequestMinimumBackoffDuration = 1 * time.Hour
+
 	defaultAutoCertificateAnnotations  = []string{"kubernetes.io/tls-acme"}
 	defaultExtraCertificateAnnotations = []string{}
 
@@ -254,6 +256,10 @@ func SetDefaults_ControllerConfiguration(obj *v1alpha1.ControllerConfiguration) 
 
 	if obj.PprofAddress == "" {
 		obj.PprofAddress = defaultProfilerAddr
+	}
+
+	if obj.CertificateRequestMinimumBackoffDuration.IsZero() {
+		obj.CertificateRequestMinimumBackoffDuration = sharedv1alpha1.DurationFromTime(defaultCertificateRequestMinimumBackoffDuration)
 	}
 
 	logsapi.SetRecommendedLoggingConfiguration(&obj.Logging)

--- a/internal/apis/config/controller/v1alpha1/testdata/defaults.json
+++ b/internal/apis/config/controller/v1alpha1/testdata/defaults.json
@@ -66,5 +66,6 @@
 	"acmeDNS01Config": {
 		"recursiveNameserversOnly": false,
 		"checkRetryPeriod": "10s"
-	}
+	},
+	"certificateRequestMinimumBackoffDuration": "1h0m0s"
 }

--- a/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
+++ b/internal/apis/config/controller/v1alpha1/zz_generated.conversion.go
@@ -214,6 +214,9 @@ func autoConvert_v1alpha1_ControllerConfiguration_To_controller_ControllerConfig
 	if err := Convert_v1alpha1_ACMEDNS01Config_To_controller_ACMEDNS01Config(&in.ACMEDNS01Config, &out.ACMEDNS01Config, s); err != nil {
 		return err
 	}
+	if err := sharedv1alpha1.Convert_Pointer_v1alpha1_Duration_To_time_Duration(&in.CertificateRequestMinimumBackoffDuration, &out.CertificateRequestMinimumBackoffDuration, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -274,6 +277,9 @@ func autoConvert_controller_ControllerConfiguration_To_v1alpha1_ControllerConfig
 		return err
 	}
 	if err := Convert_controller_ACMEDNS01Config_To_v1alpha1_ACMEDNS01Config(&in.ACMEDNS01Config, &out.ACMEDNS01Config, s); err != nil {
+		return err
+	}
+	if err := sharedv1alpha1.Convert_time_Duration_To_Pointer_v1alpha1_Duration(&in.CertificateRequestMinimumBackoffDuration, &out.CertificateRequestMinimumBackoffDuration, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/apis/config/controller/v1alpha1/types.go
+++ b/pkg/apis/config/controller/v1alpha1/types.go
@@ -135,6 +135,11 @@ type ControllerConfiguration struct {
 
 	// acmeDNS01Config configures the behaviour of the ACME DNS01 challenge solver
 	ACMEDNS01Config ACMEDNS01Config `json:"acmeDNS01Config,omitempty"`
+
+	// CertificateRequestMinimumBackoffDuration configures the initial backoff duration
+	// when a certificate request fails. This duration is exponentially increased
+	// (up to a maximum of 32 hours) based on the number of consecutive failures.
+	CertificateRequestMinimumBackoffDuration *sharedv1alpha1.Duration `json:"certificateRequestMinimumBackoffDuration,omitempty"`
 }
 
 type LeaderElectionConfig struct {

--- a/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/config/controller/v1alpha1/zz_generated.deepcopy.go
@@ -155,6 +155,11 @@ func (in *ControllerConfiguration) DeepCopyInto(out *ControllerConfiguration) {
 	in.IngressShimConfig.DeepCopyInto(&out.IngressShimConfig)
 	in.ACMEHTTP01Config.DeepCopyInto(&out.ACMEHTTP01Config)
 	in.ACMEDNS01Config.DeepCopyInto(&out.ACMEDNS01Config)
+	if in.CertificateRequestMinimumBackoffDuration != nil {
+		in, out := &in.CertificateRequestMinimumBackoffDuration, &out.CertificateRequestMinimumBackoffDuration
+		*out = new(sharedv1alpha1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -231,6 +231,10 @@ type CertificateOptions struct {
 	// CopiedAnnotationPrefixes defines which annotations should be copied
 	// Certificate -> CertificateRequest, CertificateRequest -> Order.
 	CopiedAnnotationPrefixes []string
+	// CertificateRequestMinimumBackoffDuration defines the initial backoff duration
+	// when a certificate request fails. This duration is exponentially increased
+	// based on the number of consecutive failures.
+	CertificateRequestMinimumBackoffDuration time.Duration
 }
 
 type SchedulerOptions struct {

--- a/test/integration/certificates/generates_new_private_key_per_request_test.go
+++ b/test/integration/certificates/generates_new_private_key_per_request_test.go
@@ -355,6 +355,8 @@ func runAllControllers(t *testing.T, config *rest.Config) framework.StopFunc {
 		FieldManager:              "cert-manager-certificates-issuing-test",
 	}
 
+	controllerContext.CertificateRequestMinimumBackoffDuration = 1 * time.Hour
+
 	// TODO: set field manager before calling each of those - is that what we do in actual code?
 	revCtrl, revQueue, revMustSync, err := revisionmanager.NewController(log, &controllerContext)
 	if err != nil {

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -277,6 +277,8 @@ func TestTriggerController_ExpBackoff(t *testing.T) {
 		FieldManager:              "cert-manager-certificates-trigger-test",
 	}
 
+	controllerContext.CertificateRequestMinimumBackoffDuration = 1 * time.Hour
+
 	// Start the trigger controller
 	ctrl, queue, mustSync, err := trigger.NewController(logf.Log, controllerContext, shouldReissue)
 	if err != nil {


### PR DESCRIPTION
ROSA team is observing consistent failures when using Let's Encrypt for ACME Orders and because of the default initial backoff period in cert-manager it takes an hour for retry to trigger a new issuance attempt.
Upstream has a new configuration added and part of v1.20.x, which allows customizing that CertificateRequest retry backoff period, which is backported to downstream v1.19.x release.
The fix is being backported on top of upstream 1.19.4 release.

Refer:
- https://redhat.atlassian.net/browse/SREPHOA-77
- https://github.com/cert-manager/cert-manager/issues/8259
- https://github.com/cert-manager/cert-manager/pull/8312